### PR TITLE
rds/multi-bond-support

### DIFF
--- a/ncs/app/prj.conf
+++ b/ncs/app/prj.conf
@@ -88,8 +88,8 @@ CONFIG_BT_BACKGROUND_SCAN_WINDOW=30
 
 # BLE connection and pairing limits
 CONFIG_BT_MAX_CONN=8
-# Limit to single bonded device - only pair with one MouthPad
-CONFIG_BT_MAX_PAIRED=1
+# Support up to 4 bonded devices for multi-MouthPad support
+CONFIG_BT_MAX_PAIRED=4
 CONFIG_BT_KEYS_OVERWRITE_OLDEST=y
 CONFIG_BT_GATT_DM_MAX_ATTRS=100
 CONFIG_BT_L2CAP_TX_BUF_COUNT=5

--- a/ncs/app/src/ble_central.c
+++ b/ncs/app/src/ble_central.c
@@ -714,6 +714,9 @@ static void check_bonded_device(const struct bt_bond_info *info, void *user_data
 
 	extern int ble_dis_load_info_for_addr(const bt_addr_le_t *addr, ble_dis_info_t *out_info);
 	int err = ble_dis_load_info_for_addr(&info->addr, &dis_info);
+	if (err != 0) {
+		LOG_WRN("Failed to load DIS info for %s (err: %d)", addr, err);
+	}
 
 	k_mutex_lock(&bonded_devices_mutex, K_FOREVER);
 

--- a/ncs/app/src/ble_central.c
+++ b/ncs/app/src/ble_central.c
@@ -1442,6 +1442,20 @@ int ble_central_remove_bonded_device(const bt_addr_le_t *addr)
 			bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 			LOG_INF("Removing bonded device: %s (%s)", addr_str, bonded_devices[i].name);
 
+			/* Clear DIS info for the device being removed */
+			extern void ble_dis_clear_saved_for_addr(const bt_addr_le_t *addr);
+			ble_dis_clear_saved_for_addr(addr);
+
+			/* Clear settings for this slot */
+			if (IS_ENABLED(CONFIG_SETTINGS)) {
+				char key[32];
+				snprintf(key, sizeof(key), "ble_central/bond_%d/name", i);
+				settings_delete(key);
+				snprintf(key, sizeof(key), "ble_central/bond_%d/addr", i);
+				settings_delete(key);
+			}
+
+			/* Clear in-memory data */
 			bonded_devices[i].is_valid = false;
 			memset(&bonded_devices[i].addr, 0, sizeof(bonded_devices[i].addr));
 			bonded_devices[i].name[0] = '\0';

--- a/ncs/app/src/ble_central.c
+++ b/ncs/app/src/ble_central.c
@@ -567,10 +567,41 @@ static int bonded_name_set(const char *name, size_t len, settings_read_cb read_c
 	return -ENOENT;
 }
 
+/* Display all bonded devices with names and addresses */
+static void display_bonded_devices(void)
+{
+	k_mutex_lock(&bonded_devices_mutex, K_FOREVER);
+
+	if (bonded_device_count == 0) {
+		LOG_INF("No bonded devices");
+	} else {
+		LOG_INF("=== Bonded Devices (%d/%d) ===", bonded_device_count, MAX_BONDED_DEVICES);
+		for (int i = 0; i < MAX_BONDED_DEVICES; i++) {
+			if (bonded_devices[i].is_valid) {
+				char addr_str[BT_ADDR_LE_STR_LEN];
+				bt_addr_le_to_str(&bonded_devices[i].addr, addr_str, sizeof(addr_str));
+
+				if (bonded_devices[i].name[0] != '\0') {
+					LOG_INF("  [%d] %s - %s", i, bonded_devices[i].name, addr_str);
+				} else {
+					LOG_INF("  [%d] (no name) - %s", i, addr_str);
+				}
+			}
+		}
+		LOG_INF("===========================");
+	}
+
+	k_mutex_unlock(&bonded_devices_mutex);
+}
+
 static int bonded_name_commit(void)
 {
 	/* Settings have been loaded - names are now populated in bonded_devices array */
 	LOG_INF("Settings loaded for %d bonded devices", bonded_device_count);
+
+	/* Display all bonded devices */
+	display_bonded_devices();
+
 	return 0;
 }
 

--- a/ncs/app/src/ble_central.c
+++ b/ncs/app/src/ble_central.c
@@ -667,7 +667,7 @@ static void save_bonded_device_addr(int bond_idx, const bt_addr_le_t *addr)
 		return;
 	}
 
-	char key[32];
+	char key[64];
 	snprintf(key, sizeof(key), "ble_central/bond_%d/addr", bond_idx);
 
 	int err = settings_save_one(key, addr, sizeof(bt_addr_le_t));
@@ -691,7 +691,7 @@ static void save_bonded_device_name(int bond_idx, const char *name)
 		return;
 	}
 
-	char key[32];
+	char key[64];
 	snprintf(key, sizeof(key), "ble_central/bond_%d/name", bond_idx);
 
 	int err = settings_save_one(key, name, name ? strlen(name) : 0);
@@ -1392,7 +1392,7 @@ int ble_central_add_bonded_device(const bt_addr_le_t *addr, const char *name)
 		}
 
 		/* Clear settings for this slot */
-		char key[32];
+		char key[64];
 		snprintf(key, sizeof(key), "ble_central/bond_%d/name", oldest_idx);
 		settings_delete(key);
 		snprintf(key, sizeof(key), "ble_central/bond_%d/addr", oldest_idx);
@@ -1448,7 +1448,7 @@ int ble_central_remove_bonded_device(const bt_addr_le_t *addr)
 
 			/* Clear settings for this slot */
 			if (IS_ENABLED(CONFIG_SETTINGS)) {
-				char key[32];
+				char key[64];
 				snprintf(key, sizeof(key), "ble_central/bond_%d/name", i);
 				settings_delete(key);
 				snprintf(key, sizeof(key), "ble_central/bond_%d/addr", i);
@@ -1526,7 +1526,7 @@ void ble_central_clear_bonded_device(void)
 	/* Delete saved device names from persistent settings */
 	if (IS_ENABLED(CONFIG_SETTINGS)) {
 		for (int i = 0; i < MAX_BONDED_DEVICES; i++) {
-			char key[32];
+			char key[64];
 			snprintf(key, sizeof(key), "ble_central/bond_%d/name", i);
 			settings_delete(key);
 

--- a/ncs/app/src/ble_central.c
+++ b/ncs/app/src/ble_central.c
@@ -165,12 +165,15 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 		connection_state = BLE_CENTRAL_STATE_DISCONNECTED;
 		LOG_INF("*** STATE SET TO DISCONNECTED (connection failed) ***");
 
+		/* Clean up connection reference if it was stored */
 		if (default_conn == conn) {
 			bt_conn_unref(default_conn);
 			default_conn = NULL;
-
-			(void)k_work_submit(&scan_work);
 		}
+
+		/* Always restart scanning after connection failure */
+		LOG_INF("Restarting scan after connection failure");
+		(void)k_work_submit(&scan_work);
 
 		return;
 	}

--- a/ncs/app/src/ble_central.c
+++ b/ncs/app/src/ble_central.c
@@ -1299,6 +1299,9 @@ int ble_central_get_bonded_devices(struct bonded_device *out_list, size_t max_co
 		return -EINVAL;
 	}
 
+	/* Zero the output array to prevent garbage data in unused slots */
+	memset(out_list, 0, max_count * sizeof(struct bonded_device));
+
 	k_mutex_lock(&bonded_devices_mutex, K_FOREVER);
 
 	for (int i = 0; i < MAX_BONDED_DEVICES && count < max_count; i++) {

--- a/ncs/app/src/ble_central.c
+++ b/ncs/app/src/ble_central.c
@@ -1357,6 +1357,9 @@ void ble_central_clear_bonded_device(void)
 
 	k_mutex_unlock(&bonded_devices_mutex);
 
+	/* Reset scan mode to NORMAL (in case it was in ADDITIONAL mode) */
+	scan_mode = SCAN_MODE_NORMAL;
+
 	/* Delete saved device names from persistent settings */
 	if (IS_ENABLED(CONFIG_SETTINGS)) {
 		for (int i = 0; i < MAX_BONDED_DEVICES; i++) {
@@ -1366,6 +1369,9 @@ void ble_central_clear_bonded_device(void)
 
 			snprintf(key, sizeof(key), "ble_central/bond_%d/addr", i);
 			settings_delete(key);
+
+			/* Yield to prevent blocking too long during flash operations */
+			k_yield();
 		}
 		LOG_INF("Deleted all bonded device names from persistent storage");
 	}

--- a/ncs/app/src/ble_central.c
+++ b/ncs/app/src/ble_central.c
@@ -775,16 +775,15 @@ int ble_central_init(void)
 	bonded_device_count = 0;
 	k_mutex_unlock(&bonded_devices_mutex);
 
-	/* Check if we have any bonded devices on startup */
-	bt_foreach_bond(BT_ID_DEFAULT, check_bonded_device, NULL);
-	LOG_INF("Found %d bonded device(s) at startup", bonded_device_count);
-
-	/* Load device names from settings */
+	/* Load settings BEFORE enumerating bonds (fixes bond restoration after reboot) */
 	if (IS_ENABLED(CONFIG_SETTINGS)) {
 		LOG_INF("Loading settings...");
 		settings_load();
-		LOG_INF("Settings loaded for %d bonded devices", bonded_device_count);
 	}
+
+	/* Check if we have any bonded devices (AFTER settings loaded) */
+	bt_foreach_bond(BT_ID_DEFAULT, check_bonded_device, NULL);
+	LOG_INF("Found %d bonded device(s) at startup", bonded_device_count);
 
 	/* Initialize scan without auto-connect so we can verify both HID+NUS before connecting */
 	struct bt_scan_init_param scan_init = {

--- a/ncs/app/src/ble_central.c
+++ b/ncs/app/src/ble_central.c
@@ -559,12 +559,11 @@ static int bonded_name_set(const char *name, size_t len, settings_read_cb read_c
 				temp_buf[rc] = '\0';
 
 				k_mutex_lock(&bonded_devices_mutex, K_FOREVER);
-				if (bonded_devices[bond_idx].is_valid) {
-					strncpy(bonded_devices[bond_idx].name, temp_buf,
-						sizeof(bonded_devices[bond_idx].name) - 1);
-					bonded_devices[bond_idx].name[sizeof(bonded_devices[bond_idx].name) - 1] = '\0';
-					LOG_INF("Loaded bond %d name: '%s'", bond_idx, temp_buf);
-				}
+				/* Load name regardless of is_valid (address might load after name) */
+				strncpy(bonded_devices[bond_idx].name, temp_buf,
+					sizeof(bonded_devices[bond_idx].name) - 1);
+				bonded_devices[bond_idx].name[sizeof(bonded_devices[bond_idx].name) - 1] = '\0';
+				LOG_INF("Loaded bond %d name: '%s'", bond_idx, temp_buf);
 				k_mutex_unlock(&bonded_devices_mutex);
 				return 0;
 			}

--- a/ncs/app/src/ble_central.c
+++ b/ncs/app/src/ble_central.c
@@ -598,7 +598,7 @@ static int bonded_name_set(const char *name, size_t len, settings_read_cb read_c
 					bt_addr_le_copy(&bonded_devices[bond_idx].addr, &addr);
 					bonded_devices[bond_idx].is_valid = true;
 					bonded_devices[bond_idx].last_seen = 0;
-					bonded_devices[bond_idx].name[0] = '\0';
+					/* Don't clear name - it may have already been loaded from settings */
 					bonded_device_count++;
 
 					char addr_str[BT_ADDR_LE_STR_LEN];

--- a/ncs/app/src/ble_central.h
+++ b/ncs/app/src/ble_central.h
@@ -40,10 +40,24 @@ const char *ble_central_get_device_type_string(const struct bt_scan_device_info 
 /* Background scanning for RSSI updates during connections */
 int ble_central_start_background_scan_for_rssi(void);
 
-/* Bonding management */
-void ble_central_clear_bonded_device(void);
+/* Multi-bond support - bonded device structure */
+#define MAX_BONDED_DEVICES 4
 
-/* Get bonded device address and name (returns true if bonded device exists, address/name copied to out params) */
+struct bonded_device {
+	bt_addr_le_t addr;
+	char name[32];
+	uint32_t last_seen;
+	bool is_valid;
+};
+
+/* Multi-bond management functions */
+bool ble_central_is_device_bonded(const bt_addr_le_t *addr);
+int ble_central_add_bonded_device(const bt_addr_le_t *addr, const char *name);
+int ble_central_remove_bonded_device(const bt_addr_le_t *addr);
+int ble_central_get_bonded_devices(struct bonded_device *out_list, size_t max_count);
+void ble_central_clear_bonded_device(void);  /* Clears ALL bonds */
+
+/* Get bonded device address and name (returns first bonded device for backwards compatibility) */
 bool ble_central_get_bonded_device_addr(bt_addr_le_t *out_addr, char *out_name, size_t name_size);
 
 /* Scanning state query */

--- a/ncs/app/src/ble_central.h
+++ b/ncs/app/src/ble_central.h
@@ -17,6 +17,7 @@
 int ble_central_init(void);
 int ble_central_start_scan(void);
 int ble_central_stop_scan(void);
+int ble_central_start_additional_scan(void);  /* Scan for NEW device (ignore already bonded) */
 
 /* Connection management */
 struct bt_conn *ble_central_get_default_conn(void);

--- a/ncs/app/src/ble_dis.c
+++ b/ncs/app/src/ble_dis.c
@@ -214,10 +214,10 @@ int ble_dis_load_info_for_addr(const bt_addr_le_t *addr, ble_dis_info_t *out_inf
 	char key[64];
 	build_dis_settings_key(addr, key, sizeof(key));
 
-	/* Use settings_runtime_get to load the data directly */
-	int err = settings_runtime_get(key, out_info, sizeof(ble_dis_info_t));
-	if (err <= 0) {
-		LOG_DBG("No DIS info found for device (key: %s, err: %d)", key, err);
+	/* Use settings_load_one to load the data directly */
+	ssize_t len = settings_load_one(key, out_info, sizeof(ble_dis_info_t));
+	if (len <= 0) {
+		LOG_DBG("No DIS info found for device (key: %s, len: %d)", key, (int)len);
 		return -ENOENT;
 	}
 

--- a/ncs/app/src/ble_dis.c
+++ b/ncs/app/src/ble_dis.c
@@ -67,18 +67,12 @@ static struct bt_gatt_dm_cb dis_discovery_cb = {
 /* Build settings key for a specific device address */
 static void build_dis_settings_key(const bt_addr_le_t *addr, char *key_buf, size_t buf_size)
 {
-	/* Convert address to hex string for use in settings key */
-	char addr_str[BT_ADDR_LE_STR_LEN];
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
-
-	/* Replace colons and spaces with underscores for settings key */
-	for (int i = 0; addr_str[i]; i++) {
-		if (addr_str[i] == ':' || addr_str[i] == ' ') {
-			addr_str[i] = '_';
-		}
-	}
-
-	snprintf(key_buf, buf_size, "ble_dis/%s/info", addr_str);
+	/* Create clean hex string from address bytes + type for settings key */
+	/* Format: "ble_dis/<6 hex bytes><type>/info" e.g., "ble_dis/F01A5F522A3E_1/info" */
+	snprintf(key_buf, buf_size, "ble_dis/%02X%02X%02X%02X%02X%02X_%d/info",
+		 addr->a.val[5], addr->a.val[4], addr->a.val[3],
+		 addr->a.val[2], addr->a.val[1], addr->a.val[0],
+		 addr->type);
 }
 
 static int save_dis_info_to_settings(const bt_addr_le_t *addr)

--- a/ncs/app/src/ble_dis.h
+++ b/ncs/app/src/ble_dis.h
@@ -79,7 +79,23 @@ void ble_dis_reset(void);
 const ble_dis_info_t *ble_dis_get_info(void);
 
 /**
- * @brief Clear saved device information from persistent storage
+ * @brief Load device information for a specific bonded device address
+ *
+ * @param addr BLE address of the bonded device
+ * @param out_info Output structure to fill with device info
+ * @return 0 on success, negative error code if not found or on failure
+ */
+int ble_dis_load_info_for_addr(const bt_addr_le_t *addr, ble_dis_info_t *out_info);
+
+/**
+ * @brief Clear saved device information for a specific address
+ *
+ * @param addr BLE address of the device to clear
+ */
+void ble_dis_clear_saved_for_addr(const bt_addr_le_t *addr);
+
+/**
+ * @brief Clear all saved device information from persistent storage
  *
  * This should be called when bonds are cleared to remove cached DIS info.
  */

--- a/ncs/app/src/main.c
+++ b/ncs/app/src/main.c
@@ -146,8 +146,8 @@ static void button_event_callback(button_event_t event)
 {
 	switch (event) {
 	case BUTTON_EVENT_CLICK:
-		LOG_INF("=== BUTTON CLICK ===");
-		/* TODO: Add click functionality */
+		LOG_INF("=== BUTTON CLICK - STARTING ADDITIONAL SCAN ===");
+		ble_central_start_additional_scan();
 		break;
 		
 	case BUTTON_EVENT_DOUBLE_CLICK:

--- a/ncs/app/src/main.c
+++ b/ncs/app/src/main.c
@@ -37,6 +37,8 @@ static void clear_ble_pairings(void)
 	if (ble_transport_is_connected()) {
 		LOG_INF("Disconnecting current BLE connection before clearing bonds...");
 		ble_transport_disconnect();
+		/* Wait for disconnect to complete before clearing bonds */
+		k_sleep(K_MSEC(500));
 	}
 
 	ble_transport_clear_bonds();
@@ -183,15 +185,15 @@ static void button_event_callback(button_event_t event)
 {
 	switch (event) {
 	case BUTTON_EVENT_CLICK:
-		LOG_INF("=== BUTTON CLICK - STARTING ADDITIONAL SCAN ===");
-		ble_central_start_additional_scan();
+		LOG_INF("=== BUTTON CLICK ===");
+		/* Reserved for future functionality */
 		break;
-		
+
 	case BUTTON_EVENT_DOUBLE_CLICK:
 		LOG_INF("=== BUTTON DOUBLE CLICK ===");
-		/* TODO: Add double-click functionality */
+		/* Reserved for future functionality */
 		break;
-		
+
 	case BUTTON_EVENT_HOLD:
 		LOG_INF("=== BUTTON HOLD - CLEARING BLE BONDS ===");
 		/* Clear BLE bonds and reset for new pairing */


### PR DESCRIPTION
Adds multiple bond support.

Previously only one MP^ could be bonded at a time. And then it would only re-connect to that one bonded device. 

Now the dongle will attempt to re-connect to previous bonds and if not found then auto-bond to any un-bonded advertising MP.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable bonding with up to 4 devices, prefer reconnecting to known devices, add a timed additional-scan for new devices, persist per-device DIS info, and expose a shell command to list bonds.
> 
> - **BLE Central (`src/ble_central.*`)**:
>   - **Multi-bond management**: Track up to `MAX_BONDED_DEVICES=4` with `struct bonded_device`, mutex protection, and APIs: `ble_central_is_device_bonded`, `add/remove/get_bonded_devices`, `clear_bonded_device`, `get_bonded_device_addr`.
>   - **Persistence**: Save/load bond `addr`/`name` under `settings` (`ble_central/bond_X/*`); load settings before `bt_foreach_bond`; display restored bonds at boot.
>   - **Scanning logic**: New modes `SCAN_MODE_NORMAL` (prefer bonded) and `SCAN_MODE_ADDITIONAL` (only new devices) with 10s timeout; indicator reflects mode; always restart scan on connection failure.
>   - **Pairing/startup**: On pairing, add to bonded list and exit additional mode; new state queries (`is_scanning/is_connecting/is_connected`) and `mark_services_ready`.
> - **Device Information Service (`src/ble_dis.*`)**:
>   - **Per-device storage**: Save/load DIS info per address (`ble_dis/<addr>/info`); new APIs `ble_dis_load_info_for_addr`, `ble_dis_clear_saved_for_addr`; `ble_dis_clear_saved` now only clears cache; save DIS on discovery/name read.
> - **Main (`src/main.c`)**:
>   - Add `bonds` shell command to list bonded devices; delay 500ms before clearing bonds; DeviceInfo response now loads DIS info for the connected or first bonded device.
> - **Config (`prj.conf`)**:
>   - Increase bonds: `CONFIG_BT_MAX_PAIRED=4` (was 1).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fbf109c0f5b623f2dd6ec55460176fd35373bfb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->