### PR TITLE
When bonded only connect to that MouthPad

### DIFF
--- a/ncs/app/src/ble_central.c
+++ b/ncs/app/src/ble_central.c
@@ -335,7 +335,7 @@ static void scan_filter_match(struct bt_scan_device_info *device_info,
 			bonded_device_seen_advertising = true;
 			LOG_DBG("NORMAL scan: Found bonded device: %s", addr);
 		} else if (bonded_device_count > 0) {
-			LOG_DBG("NORMAL scan: Skipping non-bonded device (already bonded to a device");
+			LOG_DBG("NORMAL scan: Skipping non-bonded device %s (already bonded to a device)", addr);
 			return;
 		}
 	}

--- a/ncs/app/src/ble_central.c
+++ b/ncs/app/src/ble_central.c
@@ -264,7 +264,7 @@ static void scan_indicator_handler(struct k_work *work)
 			LOG_INF("Scanning for ADDITIONAL MouthPad (%ds remaining, %d bonded)...",
 				remaining, bonded_device_count);
 		} else if (bonded_device_count > 0) {
-			LOG_INF("Scanning for bonded MouthPad (%d bonded)...");
+			LOG_INF("Scanning for bonded MouthPad (%d bonded)...", bonded_device_count);
 		} else {
 			LOG_INF("Scanning for MouthPad...");
 		}

--- a/ncs/app/src/ble_central.c
+++ b/ncs/app/src/ble_central.c
@@ -52,9 +52,6 @@ static int64_t additional_scan_start_time = 0;
 #define MOUTHPAD_COMPANY_ID        0x4147
 #define MOUTHPAD_MFR_DATA_PAYLOAD  "MP1"
 
-/* Track if any bonded devices are advertising in current scan session */
-static bool bonded_device_seen_advertising = false;
-
 /* Multi-bond device tracking */
 /* MAX_BONDED_DEVICES and struct bonded_device are defined in ble_central.h */
 
@@ -331,8 +328,6 @@ static void scan_filter_match(struct bt_scan_device_info *device_info,
 		LOG_INF("ADDITIONAL scan: Found NEW device: %s", addr);
 	} else {
 		if (is_bonded) {
-			/* Mark that we've seen a bonded device advertising */
-			bonded_device_seen_advertising = true;
 			LOG_DBG("NORMAL scan: Found bonded device: %s", addr);
 		} else if (bonded_device_count > 0) {
 			LOG_DBG("NORMAL scan: Skipping non-bonded device %s (already bonded to a device)", addr);
@@ -981,8 +976,6 @@ int ble_central_start_scan(void)
 		LOG_INF("Enabling HID+NUS UUID filter in ADDITIONAL scan mode (%d bonded, looking for NEW device)",
 			bonded_device_count);
 	} else if (bonded_device_count > 0) {
-		/* Reset bonded device advertising flag for new scan session */
-		bonded_device_seen_advertising = false;
 		LOG_INF("Enabling HID+NUS UUID filter in NORMAL scan mode (%d bonded devices, bonded devices only)",
 			bonded_device_count);
 	} else {

--- a/ncs/app/src/ble_central.c
+++ b/ncs/app/src/ble_central.c
@@ -336,20 +336,13 @@ static void scan_filter_match(struct bt_scan_device_info *device_info,
 		}
 		LOG_INF("ADDITIONAL scan: Found NEW device: %s", addr);
 	} else {
-		/* NORMAL mode: Always prefer bonded, but accept unbonded if no bonded devices advertising */
 		if (is_bonded) {
 			/* Mark that we've seen a bonded device advertising */
 			bonded_device_seen_advertising = true;
 			LOG_DBG("NORMAL scan: Found bonded device: %s", addr);
 		} else if (bonded_device_count > 0) {
-			/* We have bonds but this device isn't bonded */
-			if (bonded_device_seen_advertising) {
-				/* We've seen bonded devices advertising - skip unbonded */
-				LOG_DBG("NORMAL scan: Skipping non-bonded device (bonded devices available): %s", addr);
-				return;
-			}
-			/* No bonded devices seen advertising - accept unbonded as fallback */
-			LOG_INF("NORMAL scan: No bonded devices found - accepting unbonded device: %s", addr);
+			LOG_DBG("NORMAL scan: Skipping non-bonded device (already bonded to a device")
+			return;
 		}
 	}
 

--- a/ncs/app/src/ble_central.c
+++ b/ncs/app/src/ble_central.c
@@ -264,13 +264,7 @@ static void scan_indicator_handler(struct k_work *work)
 			LOG_INF("Scanning for ADDITIONAL MouthPad (%ds remaining, %d bonded)...",
 				remaining, bonded_device_count);
 		} else if (bonded_device_count > 0) {
-			if (bonded_device_seen_advertising) {
-				LOG_INF("Scanning for bonded MouthPad (%d bonded, bonded device found)...",
-					bonded_device_count);
-			} else {
-				LOG_INF("Scanning for MouthPad (prefer bonded, %d bonded)...",
-					bonded_device_count);
-			}
+			LOG_INF("Scanning for bonded MouthPad (%d bonded)...");
 		} else {
 			LOG_INF("Scanning for MouthPad...");
 		}
@@ -341,7 +335,7 @@ static void scan_filter_match(struct bt_scan_device_info *device_info,
 			bonded_device_seen_advertising = true;
 			LOG_DBG("NORMAL scan: Found bonded device: %s", addr);
 		} else if (bonded_device_count > 0) {
-			LOG_DBG("NORMAL scan: Skipping non-bonded device (already bonded to a device")
+			LOG_DBG("NORMAL scan: Skipping non-bonded device (already bonded to a device");
 			return;
 		}
 	}
@@ -989,7 +983,7 @@ int ble_central_start_scan(void)
 	} else if (bonded_device_count > 0) {
 		/* Reset bonded device advertising flag for new scan session */
 		bonded_device_seen_advertising = false;
-		LOG_INF("Enabling HID+NUS UUID filter in NORMAL scan mode (%d bonded devices, prefer bonded)",
+		LOG_INF("Enabling HID+NUS UUID filter in NORMAL scan mode (%d bonded devices, bonded devices only)",
 			bonded_device_count);
 	} else {
 		LOG_INF("Enabling HID+NUS UUID filter (no bonded devices - will pair with first MouthPad found)");


### PR DESCRIPTION
This reverts a previous product choice to prefer bonded mouthpads over newly discovered MouthPads.
With this change we can use the dongle more easily in the office for logging because we know if a
connection drops it will not start streaming data from a different MouthPad.