### PR TITLE
Sync ESP proto and handle ClearFirmwareCacheWrite

### DIFF
--- a/esp/main/mouthpad-proto/src/C/MouthpadRelay.pb.c
+++ b/esp/main/mouthpad-proto/src/C/MouthpadRelay.pb.c
@@ -18,6 +18,9 @@ PB_BIND(mouthware_message_ClearBondsWrite, mouthware_message_ClearBondsWrite, AU
 PB_BIND(mouthware_message_DfuWrite, mouthware_message_DfuWrite, AUTO)
 
 
+PB_BIND(mouthware_message_ClearFirmwareCacheWrite, mouthware_message_ClearFirmwareCacheWrite, AUTO)
+
+
 PB_BIND(mouthware_message_PassThroughToMouthpad, mouthware_message_PassThroughToMouthpad, AUTO)
 
 
@@ -34,6 +37,9 @@ PB_BIND(mouthware_message_ClearBondsResponse, mouthware_message_ClearBondsRespon
 
 
 PB_BIND(mouthware_message_DfuResponse, mouthware_message_DfuResponse, AUTO)
+
+
+PB_BIND(mouthware_message_ClearFirmwareCacheResponse, mouthware_message_ClearFirmwareCacheResponse, AUTO)
 
 
 PB_BIND(mouthware_message_PassThroughToMouthpadResponse, mouthware_message_PassThroughToMouthpadResponse, AUTO)

--- a/esp/main/mouthpad-proto/src/C/MouthpadRelay.pb.h
+++ b/esp/main/mouthpad-proto/src/C/MouthpadRelay.pb.h
@@ -71,6 +71,11 @@ typedef struct _mouthware_message_DfuWrite { /* Triggers device to enter bootloa
     char dummy_field;
 } mouthware_message_DfuWrite;
 
+typedef struct _mouthware_message_ClearFirmwareCacheWrite { /* Clears cached firmware versions for all bonded devices
+ Used when initiating firmware update to prevent false "update needed" warnings */
+    char dummy_field;
+} mouthware_message_ClearFirmwareCacheWrite;
+
 typedef PB_BYTES_ARRAY_T(240) mouthware_message_PassThroughToMouthpad_data_t;
 typedef struct _mouthware_message_PassThroughToMouthpad {
     mouthware_message_PassThroughToMouthpad_data_t data;
@@ -92,6 +97,8 @@ typedef struct _mouthware_message_AppToRelayMessage {
         mouthware_message_ClearBondsWrite clear_bonds_write;
         /* / Request to enter DFU/bootloader mode */
         mouthware_message_DfuWrite dfu_write;
+        /* / Request to clear cached firmware versions from relay */
+        mouthware_message_ClearFirmwareCacheWrite clear_firmware_cache_write;
     } message_body;
 } mouthware_message_AppToRelayMessage;
 
@@ -119,6 +126,10 @@ typedef struct _mouthware_message_DfuResponse {
     bool success;
 } mouthware_message_DfuResponse;
 
+typedef struct _mouthware_message_ClearFirmwareCacheResponse {
+    bool success;
+} mouthware_message_ClearFirmwareCacheResponse;
+
 typedef struct _mouthware_message_PassThroughToMouthpadResponse {
     mouthware_message_PassThroughToMouthpadErrorCode error_code;
 } mouthware_message_PassThroughToMouthpadResponse;
@@ -144,6 +155,8 @@ typedef struct _mouthware_message_RelayToAppMessage {
         mouthware_message_ClearBondsResponse clear_bonds_response;
         /* / Response to a DfuWrite */
         mouthware_message_DfuResponse dfu_response;
+        /* / Response to a ClearFirmwareCacheWrite */
+        mouthware_message_ClearFirmwareCacheResponse clear_firmware_cache_response;
     } message_body;
 } mouthware_message_RelayToAppMessage;
 
@@ -178,12 +191,14 @@ extern "C" {
 
 
 
+
 #define mouthware_message_AppToRelayMessage_destination_ENUMTYPE mouthware_message_AppToRelayMessageDestination
 
 #define mouthware_message_BleConnectionStatusResponse_connection_status_ENUMTYPE mouthware_message_RelayBleConnectionStatus
 
 #define mouthware_message_DeviceInfoResponse_family_ENUMTYPE mouthware_message_DeviceFamily
 #define mouthware_message_DeviceInfoResponse_board_ENUMTYPE mouthware_message_DeviceBoard
+
 
 
 
@@ -197,12 +212,14 @@ extern "C" {
 #define mouthware_message_DeviceInfoRead_init_default {0}
 #define mouthware_message_ClearBondsWrite_init_default {0}
 #define mouthware_message_DfuWrite_init_default  {0}
+#define mouthware_message_ClearFirmwareCacheWrite_init_default {0}
 #define mouthware_message_PassThroughToMouthpad_init_default {{0, {0}}}
 #define mouthware_message_AppToRelayMessage_init_default {_mouthware_message_AppToRelayMessageDestination_MIN, 0, {mouthware_message_BleConnectionStatusRead_init_default}}
 #define mouthware_message_BleConnectionStatusResponse_init_default {_mouthware_message_RelayBleConnectionStatus_MIN, 0, 0}
 #define mouthware_message_DeviceInfoResponse_init_default {{{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, 0, 0, _mouthware_message_DeviceFamily_MIN, _mouthware_message_DeviceBoard_MIN}
 #define mouthware_message_ClearBondsResponse_init_default {0}
 #define mouthware_message_DfuResponse_init_default {0}
+#define mouthware_message_ClearFirmwareCacheResponse_init_default {0}
 #define mouthware_message_PassThroughToMouthpadResponse_init_default {_mouthware_message_PassThroughToMouthpadErrorCode_MIN}
 #define mouthware_message_PassThroughToApp_init_default {{0, {0}}}
 #define mouthware_message_RelayToAppMessage_init_default {0, {mouthware_message_BleConnectionStatusResponse_init_default}}
@@ -210,12 +227,14 @@ extern "C" {
 #define mouthware_message_DeviceInfoRead_init_zero {0}
 #define mouthware_message_ClearBondsWrite_init_zero {0}
 #define mouthware_message_DfuWrite_init_zero     {0}
+#define mouthware_message_ClearFirmwareCacheWrite_init_zero {0}
 #define mouthware_message_PassThroughToMouthpad_init_zero {{0, {0}}}
 #define mouthware_message_AppToRelayMessage_init_zero {_mouthware_message_AppToRelayMessageDestination_MIN, 0, {mouthware_message_BleConnectionStatusRead_init_zero}}
 #define mouthware_message_BleConnectionStatusResponse_init_zero {_mouthware_message_RelayBleConnectionStatus_MIN, 0, 0}
 #define mouthware_message_DeviceInfoResponse_init_zero {{{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, 0, 0, _mouthware_message_DeviceFamily_MIN, _mouthware_message_DeviceBoard_MIN}
 #define mouthware_message_ClearBondsResponse_init_zero {0}
 #define mouthware_message_DfuResponse_init_zero  {0}
+#define mouthware_message_ClearFirmwareCacheResponse_init_zero {0}
 #define mouthware_message_PassThroughToMouthpadResponse_init_zero {_mouthware_message_PassThroughToMouthpadErrorCode_MIN}
 #define mouthware_message_PassThroughToApp_init_zero {{0, {0}}}
 #define mouthware_message_RelayToAppMessage_init_zero {0, {mouthware_message_BleConnectionStatusResponse_init_zero}}
@@ -228,6 +247,7 @@ extern "C" {
 #define mouthware_message_AppToRelayMessage_device_info_read_tag 4
 #define mouthware_message_AppToRelayMessage_clear_bonds_write_tag 5
 #define mouthware_message_AppToRelayMessage_dfu_write_tag 6
+#define mouthware_message_AppToRelayMessage_clear_firmware_cache_write_tag 7
 #define mouthware_message_BleConnectionStatusResponse_connection_status_tag 1
 #define mouthware_message_BleConnectionStatusResponse_rssi_tag 2
 #define mouthware_message_BleConnectionStatusResponse_battery_level_tag 3
@@ -240,6 +260,7 @@ extern "C" {
 #define mouthware_message_DeviceInfoResponse_board_tag 7
 #define mouthware_message_ClearBondsResponse_success_tag 1
 #define mouthware_message_DfuResponse_success_tag 1
+#define mouthware_message_ClearFirmwareCacheResponse_success_tag 1
 #define mouthware_message_PassThroughToMouthpadResponse_error_code_tag 1
 #define mouthware_message_PassThroughToApp_data_tag 1
 #define mouthware_message_RelayToAppMessage_ble_connection_status_response_tag 1
@@ -248,6 +269,7 @@ extern "C" {
 #define mouthware_message_RelayToAppMessage_device_info_response_tag 4
 #define mouthware_message_RelayToAppMessage_clear_bonds_response_tag 5
 #define mouthware_message_RelayToAppMessage_dfu_response_tag 6
+#define mouthware_message_RelayToAppMessage_clear_firmware_cache_response_tag 7
 
 /* Struct field encoding specification for nanopb */
 #define mouthware_message_BleConnectionStatusRead_FIELDLIST(X, a) \
@@ -270,6 +292,11 @@ extern "C" {
 #define mouthware_message_DfuWrite_CALLBACK NULL
 #define mouthware_message_DfuWrite_DEFAULT NULL
 
+#define mouthware_message_ClearFirmwareCacheWrite_FIELDLIST(X, a) \
+
+#define mouthware_message_ClearFirmwareCacheWrite_CALLBACK NULL
+#define mouthware_message_ClearFirmwareCacheWrite_DEFAULT NULL
+
 #define mouthware_message_PassThroughToMouthpad_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, BYTES,    data,              1)
 #define mouthware_message_PassThroughToMouthpad_CALLBACK NULL
@@ -281,7 +308,8 @@ X(a, STATIC,   ONEOF,    MESSAGE,  (message_body,ble_connection_status_read,mess
 X(a, STATIC,   ONEOF,    MESSAGE,  (message_body,pass_through_to_mouthpad,message_body.pass_through_to_mouthpad),   3) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (message_body,device_info_read,message_body.device_info_read),   4) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (message_body,clear_bonds_write,message_body.clear_bonds_write),   5) \
-X(a, STATIC,   ONEOF,    MESSAGE,  (message_body,dfu_write,message_body.dfu_write),   6)
+X(a, STATIC,   ONEOF,    MESSAGE,  (message_body,dfu_write,message_body.dfu_write),   6) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (message_body,clear_firmware_cache_write,message_body.clear_firmware_cache_write),   7)
 #define mouthware_message_AppToRelayMessage_CALLBACK NULL
 #define mouthware_message_AppToRelayMessage_DEFAULT NULL
 #define mouthware_message_AppToRelayMessage_message_body_ble_connection_status_read_MSGTYPE mouthware_message_BleConnectionStatusRead
@@ -289,6 +317,7 @@ X(a, STATIC,   ONEOF,    MESSAGE,  (message_body,dfu_write,message_body.dfu_writ
 #define mouthware_message_AppToRelayMessage_message_body_device_info_read_MSGTYPE mouthware_message_DeviceInfoRead
 #define mouthware_message_AppToRelayMessage_message_body_clear_bonds_write_MSGTYPE mouthware_message_ClearBondsWrite
 #define mouthware_message_AppToRelayMessage_message_body_dfu_write_MSGTYPE mouthware_message_DfuWrite
+#define mouthware_message_AppToRelayMessage_message_body_clear_firmware_cache_write_MSGTYPE mouthware_message_ClearFirmwareCacheWrite
 
 #define mouthware_message_BleConnectionStatusResponse_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, UENUM,    connection_status,   1) \
@@ -318,6 +347,11 @@ X(a, STATIC,   SINGULAR, BOOL,     success,           1)
 #define mouthware_message_DfuResponse_CALLBACK NULL
 #define mouthware_message_DfuResponse_DEFAULT NULL
 
+#define mouthware_message_ClearFirmwareCacheResponse_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, BOOL,     success,           1)
+#define mouthware_message_ClearFirmwareCacheResponse_CALLBACK NULL
+#define mouthware_message_ClearFirmwareCacheResponse_DEFAULT NULL
+
 #define mouthware_message_PassThroughToMouthpadResponse_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, UENUM,    error_code,        1)
 #define mouthware_message_PassThroughToMouthpadResponse_CALLBACK NULL
@@ -334,7 +368,8 @@ X(a, STATIC,   ONEOF,    MESSAGE,  (message_body,pass_through_to_mouthpad_respon
 X(a, STATIC,   ONEOF,    MESSAGE,  (message_body,pass_through_to_app,message_body.pass_through_to_app),   3) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (message_body,device_info_response,message_body.device_info_response),   4) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (message_body,clear_bonds_response,message_body.clear_bonds_response),   5) \
-X(a, STATIC,   ONEOF,    MESSAGE,  (message_body,dfu_response,message_body.dfu_response),   6)
+X(a, STATIC,   ONEOF,    MESSAGE,  (message_body,dfu_response,message_body.dfu_response),   6) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (message_body,clear_firmware_cache_response,message_body.clear_firmware_cache_response),   7)
 #define mouthware_message_RelayToAppMessage_CALLBACK NULL
 #define mouthware_message_RelayToAppMessage_DEFAULT NULL
 #define mouthware_message_RelayToAppMessage_message_body_ble_connection_status_response_MSGTYPE mouthware_message_BleConnectionStatusResponse
@@ -343,17 +378,20 @@ X(a, STATIC,   ONEOF,    MESSAGE,  (message_body,dfu_response,message_body.dfu_r
 #define mouthware_message_RelayToAppMessage_message_body_device_info_response_MSGTYPE mouthware_message_DeviceInfoResponse
 #define mouthware_message_RelayToAppMessage_message_body_clear_bonds_response_MSGTYPE mouthware_message_ClearBondsResponse
 #define mouthware_message_RelayToAppMessage_message_body_dfu_response_MSGTYPE mouthware_message_DfuResponse
+#define mouthware_message_RelayToAppMessage_message_body_clear_firmware_cache_response_MSGTYPE mouthware_message_ClearFirmwareCacheResponse
 
 extern const pb_msgdesc_t mouthware_message_BleConnectionStatusRead_msg;
 extern const pb_msgdesc_t mouthware_message_DeviceInfoRead_msg;
 extern const pb_msgdesc_t mouthware_message_ClearBondsWrite_msg;
 extern const pb_msgdesc_t mouthware_message_DfuWrite_msg;
+extern const pb_msgdesc_t mouthware_message_ClearFirmwareCacheWrite_msg;
 extern const pb_msgdesc_t mouthware_message_PassThroughToMouthpad_msg;
 extern const pb_msgdesc_t mouthware_message_AppToRelayMessage_msg;
 extern const pb_msgdesc_t mouthware_message_BleConnectionStatusResponse_msg;
 extern const pb_msgdesc_t mouthware_message_DeviceInfoResponse_msg;
 extern const pb_msgdesc_t mouthware_message_ClearBondsResponse_msg;
 extern const pb_msgdesc_t mouthware_message_DfuResponse_msg;
+extern const pb_msgdesc_t mouthware_message_ClearFirmwareCacheResponse_msg;
 extern const pb_msgdesc_t mouthware_message_PassThroughToMouthpadResponse_msg;
 extern const pb_msgdesc_t mouthware_message_PassThroughToApp_msg;
 extern const pb_msgdesc_t mouthware_message_RelayToAppMessage_msg;
@@ -363,12 +401,14 @@ extern const pb_msgdesc_t mouthware_message_RelayToAppMessage_msg;
 #define mouthware_message_DeviceInfoRead_fields &mouthware_message_DeviceInfoRead_msg
 #define mouthware_message_ClearBondsWrite_fields &mouthware_message_ClearBondsWrite_msg
 #define mouthware_message_DfuWrite_fields &mouthware_message_DfuWrite_msg
+#define mouthware_message_ClearFirmwareCacheWrite_fields &mouthware_message_ClearFirmwareCacheWrite_msg
 #define mouthware_message_PassThroughToMouthpad_fields &mouthware_message_PassThroughToMouthpad_msg
 #define mouthware_message_AppToRelayMessage_fields &mouthware_message_AppToRelayMessage_msg
 #define mouthware_message_BleConnectionStatusResponse_fields &mouthware_message_BleConnectionStatusResponse_msg
 #define mouthware_message_DeviceInfoResponse_fields &mouthware_message_DeviceInfoResponse_msg
 #define mouthware_message_ClearBondsResponse_fields &mouthware_message_ClearBondsResponse_msg
 #define mouthware_message_DfuResponse_fields &mouthware_message_DfuResponse_msg
+#define mouthware_message_ClearFirmwareCacheResponse_fields &mouthware_message_ClearFirmwareCacheResponse_msg
 #define mouthware_message_PassThroughToMouthpadResponse_fields &mouthware_message_PassThroughToMouthpadResponse_msg
 #define mouthware_message_PassThroughToApp_fields &mouthware_message_PassThroughToApp_msg
 #define mouthware_message_RelayToAppMessage_fields &mouthware_message_RelayToAppMessage_msg
@@ -382,6 +422,8 @@ extern const pb_msgdesc_t mouthware_message_RelayToAppMessage_msg;
 #define mouthware_message_BleConnectionStatusResponse_size 19
 #define mouthware_message_ClearBondsResponse_size 2
 #define mouthware_message_ClearBondsWrite_size   0
+#define mouthware_message_ClearFirmwareCacheResponse_size 2
+#define mouthware_message_ClearFirmwareCacheWrite_size 0
 #define mouthware_message_DeviceInfoRead_size    0
 #define mouthware_message_DfuResponse_size       2
 #define mouthware_message_DfuWrite_size          0

--- a/esp/main/relay_protocol.c
+++ b/esp/main/relay_protocol.c
@@ -29,6 +29,7 @@ static int32_t s_last_rssi = 0;
 static esp_err_t handle_ble_connection_status_read(void);
 static esp_err_t handle_device_info_read(void);
 static esp_err_t handle_clear_bonds_write(void);
+static esp_err_t handle_clear_firmware_cache_write(void);
 static esp_err_t handle_dfu_write(void);
 static esp_err_t handle_pass_through_to_mouthpad(const uint8_t *data, size_t len);
 
@@ -85,6 +86,11 @@ esp_err_t relay_protocol_handle_usb_data(const uint8_t *data, uint16_t len) {
         case mouthware_message_AppToRelayMessage_clear_bonds_write_tag:
             ESP_LOGD(TAG, "Handling ClearBondsWrite");
             ret = handle_clear_bonds_write();
+            break;
+
+        case mouthware_message_AppToRelayMessage_clear_firmware_cache_write_tag:
+            ESP_LOGD(TAG, "Handling ClearFirmwareCacheWrite");
+            ret = handle_clear_firmware_cache_write();
             break;
 
         case mouthware_message_AppToRelayMessage_dfu_write_tag:
@@ -311,6 +317,18 @@ static esp_err_t handle_clear_bonds_write(void) {
     // Perform bond reset (disconnect device + clear all bonds)
     esp_err_t ret = perform_bond_reset();
     relay_msg.message_body.clear_bonds_response.success = (ret == ESP_OK);
+
+    return relay_protocol_send_response(&relay_msg);
+}
+
+static esp_err_t handle_clear_firmware_cache_write(void) {
+    ESP_LOGI(TAG, "=== CLEAR FIRMWARE CACHE REQUEST (via protobuf) ===");
+
+    mouthware_message_RelayToAppMessage relay_msg = mouthware_message_RelayToAppMessage_init_zero;
+    relay_msg.which_message_body = mouthware_message_RelayToAppMessage_clear_firmware_cache_response_tag;
+
+    esp_err_t ret = ble_device_info_clear_saved();
+    relay_msg.message_body.clear_firmware_cache_response.success = (ret == ESP_OK);
 
     return relay_protocol_send_response(&relay_msg);
 }


### PR DESCRIPTION
## Summary
- Sync ESP-vendored `MouthpadRelay.pb.{c,h}` with `mouthpad-utility` `main` (proto SHA `2e686a8`). The NCS vendor copy was already at this version; only ESP had drifted.
- Add `clear_firmware_cache_write_tag` case in `relay_protocol.c` that calls existing `ble_device_info_clear_saved()` (clears cached DIS firmware revision from NVS) and emits `ClearFirmwareCacheResponse`. Mirrors the NCS handler.

## Why
The utility app's developer firmware-update flow (utility PR #160) sends `ClearFirmwareCacheWrite` to the dongle so cached firmware versions don't trigger false "update needed" warnings after a flash. The ESP dongle was decoding this as an unknown tag and dropping it. NCS already handled it.

## Exposure check
Only `MouthpadRelay.pb.{c,h}` (relay protocol bindings) are vendored from the private `mouthpad-proto` repo — no `.proto` sources, no `Mouthpad.proto` device API, no other schemas or language bindings. Surface area unchanged from prior commits.

## Test plan
- [x] `idf.py build` succeeds for `seeed_xiao_esp32s3`
- [ ] Smoke test on hardware: utility-initiated firmware update no longer surfaces stale-firmware warnings post-flash
- [ ] Confirm `ClearFirmwareCacheResponse.success=true` returns to the app over USB CDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)